### PR TITLE
feat: add variable manage_fastly_dictionary_items

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,21 @@ module "fingerprint_fastly_vcl_integration" {
 
 You can see the full list of the Terraform module's variables below:
 
-| Variable                     | Description                                               | Required | Example                                        |
-| ---------------------------- | --------------------------------------------------------- | -------- | ---------------------------------------------- |
-| `fastly_api_token`           | Your Fastly API token                                     | Required | `"ABC123...xyz"`                               |
-| `proxy_secret`               | Your Fingerprint proxy secret                             | Required | `"9h7jk2s1"`                                   |
-| `integration_path`           | Path prefix for proxy requests                            | Required | `"kyfy7t0a"`                                   |
-| `agent_script_download_path` | Path for serving the JavaScript agent                     | Required | `"cc7bu2o8"`                                   |
-| `get_result_path`            | Path for identification requests                          | Required | `"sy5k3279"`                                   |
-| `integration_domain`         | Domain used for the proxy integration                     | Required | `"metrics.yourwebsite.com"`                    |
-| `main_host`                  | Your origin server domain                                 | Required | `"yourwebsite.com"`                            |
-| `dictionary_name`            | Name of the Fastly Dictionary for config values           | Optional | `"fingerprint_config"`                         |
-| `integration_name`           | Name of the Fastly CDN service                            | Optional | `"fingerprint-fastly-vcl-proxy-integration"`   |
-| `download_asset`             | Whether to auto-download the latest VCL release           | Optional | `true`                                         |
-| `vcl_asset_name`             | Custom VCL asset file if not downloading the official one | Optional | `"fingerprint-pro-fastly-vcl-integration.vcl"` |
-| `asset_version`              | GitHub release version used for the VCL asset             | Optional | `"latest"`                                     |
+| Variable                         | Description                                                                                                                                                                                   | Required | Example                                        |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------|
+| `fastly_api_token`               | Your Fastly API token                                                                                                                                                                         | Required | `"ABC123...xyz"`                               |
+| `proxy_secret`                   | Your Fingerprint proxy secret                                                                                                                                                                 | Required | `"9h7jk2s1"`                                   |
+| `integration_path`               | Path prefix for proxy requests                                                                                                                                                                | Required | `"kyfy7t0a"`                                   |
+| `agent_script_download_path`     | Path for serving the JavaScript agent                                                                                                                                                         | Required | `"cc7bu2o8"`                                   |
+| `get_result_path`                | Path for identification requests                                                                                                                                                              | Required | `"sy5k3279"`                                   |
+| `integration_domain`             | Domain used for the proxy integration                                                                                                                                                         | Required | `"metrics.yourwebsite.com"`                    |
+| `main_host`                      | Your origin server domain                                                                                                                                                                     | Required | `"yourwebsite.com"`                            |
+| `dictionary_name`                | Name of the Fastly Dictionary for config values                                                                                                                                               | Optional | `"fingerprint_config"`                         |
+| `integration_name`               | Name of the Fastly CDN service                                                                                                                                                                | Optional | `"fingerprint-fastly-vcl-proxy-integration"`   |
+| `download_asset`                 | Whether to auto-download the latest VCL release                                                                                                                                               | Optional | `true`                                         |
+| `vcl_asset_name`                 | Custom VCL asset file if not downloading the official one                                                                                                                                     | Optional | `"fingerprint-pro-fastly-vcl-integration.vcl"` |
+| `asset_version`                  | GitHub release version used for the VCL asset                                                                                                                                                 | Optional | `"latest"`                                     |
+| `manage_fastly_dictionary_items` | Manage Fastly Dictionary items via terraform, see [Fastly documentation](https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_dictionary_items#manage_items-1) | Optional | `false`                                        |
 
 ## 2. Deploy your Terraform changes
 

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ resource "fastly_service_vcl" "fingerprint_integration" {
 resource "fastly_service_dictionary_items" "fingerprint_integration_dictionary_items" {
   service_id    = fastly_service_vcl.fingerprint_integration.id
   dictionary_id = local.selected_dictionary.dictionary_id
+  manage_entries = var.manage_fastly_dictionary_items
   items = {
     PROXY_SECRET : var.proxy_secret,
     INTEGRATION_PATH : var.integration_path,

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,13 @@ variable "dictionary_name" {
   }
 }
 
+variable "manage_fastly_dictionary_items" {
+  type = bool
+  default = false
+  nullable = false
+  description = "Manage Fastly Dictionary items via terraform, see link: https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_dictionary_items#manage_items-1"
+}
+
 variable "integration_name" {
   type = string
   default = "fingerprint-fastly-vcl-proxy-integration"


### PR DESCRIPTION
This PR introduces:

- A workaround for Fastly's default behavior about managing store items via Terraform